### PR TITLE
[Feat] : CareerIntro 페이지 구현

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "@types/react-dom": "^19.1.5",
         "axios": "^1.9.0",
         "crypto-js": "^4.2.0",
+        "framer-motion": "^12.19.1",
         "react": "^19.1.0",
         "react-dom": "^19.1.0",
         "react-icons": "^5.4.0",
@@ -24,7 +25,7 @@
         "react-router-dom": "^7.6.1",
         "react-scripts": "5.0.1",
         "react-select": "^5.10.1",
-        "styled-components": "^6.1.18",
+        "styled-components": "^6.1.19",
         "typescript": "^4.9.5",
         "web-vitals": "^2.1.4",
         "zustand": "^5.0.5"
@@ -8908,6 +8909,33 @@
         "url": "https://github.com/sponsors/rawify"
       }
     },
+    "node_modules/framer-motion": {
+      "version": "12.19.1",
+      "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-12.19.1.tgz",
+      "integrity": "sha512-nq9hwWAEKf4gzprbOZzKugLV5OVKF7zrNDY6UOVu+4D3ZgIkg8L9Jy6AMrpBM06fhbKJ6LEG6UY5+t7Eq6wNlg==",
+      "license": "MIT",
+      "dependencies": {
+        "motion-dom": "^12.19.0",
+        "motion-utils": "^12.19.0",
+        "tslib": "^2.4.0"
+      },
+      "peerDependencies": {
+        "@emotion/is-prop-valid": "*",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@emotion/is-prop-valid": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/fresh": {
       "version": "0.5.2",
       "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
@@ -12716,6 +12744,21 @@
       "bin": {
         "mkdirp": "bin/cmd.js"
       }
+    },
+    "node_modules/motion-dom": {
+      "version": "12.19.0",
+      "resolved": "https://registry.npmjs.org/motion-dom/-/motion-dom-12.19.0.tgz",
+      "integrity": "sha512-m96uqq8VbwxFLU0mtmlsIVe8NGGSdpBvBSHbnnOJQxniPaabvVdGgxSamhuDwBsRhwX7xPxdICgVJlOpzn/5bw==",
+      "license": "MIT",
+      "dependencies": {
+        "motion-utils": "^12.19.0"
+      }
+    },
+    "node_modules/motion-utils": {
+      "version": "12.19.0",
+      "resolved": "https://registry.npmjs.org/motion-utils/-/motion-utils-12.19.0.tgz",
+      "integrity": "sha512-BuFTHINYmV07pdWs6lj6aI63vr2N4dg0vR+td0rtrdpWOhBzIkEklZyLcvKBoEtwSqx8Jg06vUB5RS0xDiUybw==",
+      "license": "MIT"
     },
     "node_modules/ms": {
       "version": "2.1.3",
@@ -17041,9 +17084,9 @@
       }
     },
     "node_modules/styled-components": {
-      "version": "6.1.18",
-      "resolved": "https://registry.npmjs.org/styled-components/-/styled-components-6.1.18.tgz",
-      "integrity": "sha512-Mvf3gJFzZCkhjY2Y/Fx9z1m3dxbza0uI9H1CbNZm/jSHCojzJhQ0R7bByrlFJINnMzz/gPulpoFFGymNwrsMcw==",
+      "version": "6.1.19",
+      "resolved": "https://registry.npmjs.org/styled-components/-/styled-components-6.1.19.tgz",
+      "integrity": "sha512-1v/e3Dl1BknC37cXMhwGomhO8AkYmN41CqyX9xhUDxry1ns3BFQy2lLDRQXJRdVVWB9OHemv/53xaStimvWyuA==",
       "license": "MIT",
       "dependencies": {
         "@emotion/is-prop-valid": "1.2.2",

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "@types/react-dom": "^19.1.5",
     "axios": "^1.9.0",
     "crypto-js": "^4.2.0",
+    "framer-motion": "^12.19.1",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
     "react-icons": "^5.4.0",
@@ -19,7 +20,7 @@
     "react-router-dom": "^7.6.1",
     "react-scripts": "5.0.1",
     "react-select": "^5.10.1",
-    "styled-components": "^6.1.18",
+    "styled-components": "^6.1.19",
     "typescript": "^4.9.5",
     "web-vitals": "^2.1.4",
     "zustand": "^5.0.5"

--- a/src/api/certi.ts
+++ b/src/api/certi.ts
@@ -17,3 +17,8 @@ export const initializeCertifications = async (certifications: CertificationDto[
     throw error;
   }
 };
+
+export const fetchCertificationAll = async () => {
+  const response = await api.get('/profiles/me/certifications/all');
+  return response.data.result;
+};

--- a/src/api/experience.ts
+++ b/src/api/experience.ts
@@ -12,3 +12,8 @@ export const initializeExperience = async (experiences: ExperienceDto[]) => {
     throw error;
   }
 };
+
+export const fetchExperienceAll = async () => {
+  const response = await api.get('/profiles/me/experiences/all');
+  return response.data.result;
+};

--- a/src/api/project.ts
+++ b/src/api/project.ts
@@ -27,3 +27,8 @@ export const initializeProjects = async (projects: ProjectFormDto[]) => {
     throw error;
   }
 };
+
+export const fetchProjectAll = async () => {
+  const response = await api.get('/profiles/me/projects/all');
+  return response.data.result;
+};

--- a/src/components/career/CareerReveal.tsx
+++ b/src/components/career/CareerReveal.tsx
@@ -1,0 +1,61 @@
+import React from 'react';
+import { motion } from 'framer-motion';
+import styled from 'styled-components';
+
+interface CareerRevealProps {
+  projectCount: number;
+  experienceCount: number;
+  certificationCount: number;
+}
+
+const OuterWrapper = styled.div`
+  display: flex;
+  justify-content: center;
+  align-items: flex-start;
+  height: 100vh;
+  padding-top: 20vh;
+`;
+const InnerWrapper = styled(motion.div)`
+  text-align: center;
+  font-size: 1.25rem;
+  line-height: 1.5;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+`;
+const container = {
+  hidden: { opacity: 0 },
+  visible: {
+    opacity: 1,
+    transition: {
+      staggerChildren: 1.5,
+    },
+  },
+};
+
+const item = {
+  hidden: { opacity: 0, y: 20 },
+  visible: { opacity: 1, y: 0 },
+};
+
+const CareerReveal = ({ projectCount, experienceCount, certificationCount }: CareerRevealProps) => {
+  const lines = [
+    '당신의 커리어를 분석 중입니다...',
+    `✔ ${projectCount}개의 프로젝트를 수행했어요.`,
+    `✔ ${experienceCount}번의 성장 경험이 있어요.`,
+    `✔ ${certificationCount}개의 자격증이 확인되었어요.`,
+  ];
+  return (
+    <OuterWrapper>
+      <InnerWrapper variants={container} initial="hidden" animate="visible">
+        {lines.map((line, index) => (
+          <motion.p key={index} variants={item}>
+            {line}
+          </motion.p>
+        ))}
+      </InnerWrapper>
+    </OuterWrapper>
+  );
+};
+
+export default CareerReveal;

--- a/src/components/career/CareerStepper.tsx
+++ b/src/components/career/CareerStepper.tsx
@@ -1,0 +1,255 @@
+import React, { useState } from 'react';
+import styled from 'styled-components';
+import { motion, easeOut } from 'framer-motion';
+
+interface CareerSection<T> {
+  title: string;
+  subtitle?: string;
+  items: T[];
+  renderItem: (item: T, index: number) => React.ReactNode;
+}
+
+interface CareerStepperProps<T> {
+  sections: CareerSection<T>[];
+  onComplete: () => void;
+}
+
+const Wrapper = styled.div`
+  max-width: 1200px;
+  margin: 0 auto;
+  height: 90vh;
+  // padding: 2rem 1rem;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  overflow: hidden;
+`;
+
+const Container = styled.div`
+  display: flex;
+  flex-direction: column;
+  background: rgba(255, 255, 255, 0.1);
+  backdrop-filter: blur(10px);
+  border-radius: 24px;
+  padding: 1rem;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+  border: 0.5px solid rgba(234, 67, 53, 0.1);
+  height: 100%;
+`;
+
+const Header = styled.div`
+  text-align: center;
+  margin-bottom: 3rem;
+`;
+
+const Title = styled.h2`
+  font-size: 2.5rem;
+  font-weight: 700;
+  background: linear-gradient(135deg, #ff6b6b 0%, #ff8787 100%);
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  background-clip: text;
+  margin-bottom: 0.5rem;
+  line-height: 1.2;
+
+  @media (max-width: 768px) {
+    font-size: 2rem;
+  }
+`;
+
+const CardsGrid = styled.div`
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+  gap: 1.5rem;
+  margin-bottom: 3rem;
+
+  @media (max-width: 768px) {
+    grid-template-columns: 1fr;
+    gap: 1rem;
+  }
+`;
+
+const Content = styled.div`
+  flex: 1;
+  overflow-y: auto;
+  padding-bottom: 2rem; /* 버튼과 겹치지 않게 여유 공간 */
+`;
+
+const EmptyState = styled.div`
+  text-align: center;
+  padding: 4rem 2rem;
+  color: #64748b;
+`;
+
+const EmptyTitle = styled.h3`
+  font-size: 1.5rem;
+  font-weight: 600;
+  margin-bottom: 0.5rem;
+  color: #475569;
+`;
+
+const EmptyDescription = styled.p`
+  font-size: 1rem;
+  color: #64748b;
+`;
+
+const ButtonContainer = styled.div`
+  text-align: center;
+`;
+
+const Button = styled(motion.button)`
+  background: linear-gradient(135deg, #ff6b6b 0%, #ff8787 100%);
+  color: white;
+  padding: 1rem 2.5rem;
+  font-size: 1.1rem;
+  border: none;
+  border-radius: 12px;
+  font-weight: 600;
+  cursor: pointer;
+  box-shadow: 0 4px 15px rgba(234, 67, 53, 0.4);
+  transition: all 0.3s ease;
+  position: relative;
+  overflow: hidden;
+
+  &:hover {
+    transform: translateY(-2px);
+    box-shadow: 0 8px 25px rgba(234, 67, 53, 0.5);
+  }
+
+  &:active {
+    transform: translateY(0);
+  }
+
+  &::before {
+    content: '';
+    position: absolute;
+    top: 0;
+    left: -100%;
+    width: 100%;
+    height: 100%;
+    transition: left 0.5s;
+  }
+
+  &:hover::before {
+    left: 100%;
+  }
+`;
+
+// 컨테이너 애니메이션 (전체 그리드)
+const containerVariants = {
+  hidden: { opacity: 0 },
+  visible: {
+    opacity: 1,
+    transition: {
+      staggerChildren: 0.3, // 각 자식 요소 사이의 딜레이
+      delayChildren: 0.1, // 첫 번째 자식 요소의 딜레이
+    },
+  },
+  exit: {
+    opacity: 0,
+    transition: {
+      staggerChildren: 0.05,
+      staggerDirection: -1, // 역순으로 사라짐
+    },
+  },
+};
+
+// 각 카드 애니메이션
+const itemVariants = {
+  hidden: {
+    opacity: 0,
+    y: 30,
+    scale: 0.9,
+  },
+  visible: {
+    opacity: 1,
+    y: 0,
+    scale: 1,
+    transition: {
+      // type: 'spring' as const,
+      // stiffness: 300,
+      // damping: 24,
+      // duration: 0.8,
+      type: 'tween' as const,
+      ease: easeOut,
+      duration: 1.2,
+    },
+  },
+  exit: {
+    opacity: 0,
+    y: -20,
+    scale: 0.9,
+    transition: {
+      duration: 0.3,
+    },
+  },
+};
+
+const CareerStepper = <T,>({ sections, onComplete }: CareerStepperProps<T>) => {
+  const [step, setStep] = useState(0);
+
+  const handleNext = () => {
+    if (step < sections.length - 1) {
+      setStep((prev) => prev + 1);
+    } else {
+      onComplete();
+    }
+  };
+
+  const currentSection = sections[step];
+
+  return (
+    <Wrapper>
+      <Container>
+        <Content>
+          <Header>
+            <motion.div initial={{ opacity: 0, y: -20 }} animate={{ opacity: 1, y: 0 }} transition={{ duration: 0.5 }}>
+              <Title>{currentSection.title}</Title>
+            </motion.div>
+          </Header>
+
+          {currentSection.items.length > 0 ? (
+            <motion.div key={step} variants={containerVariants} initial="hidden" animate="visible" exit="exit">
+              <CardsGrid>
+                {currentSection.items.map((item, index) => (
+                  <motion.div key={`${step}-${index}`} variants={itemVariants}>
+                    {currentSection.renderItem(item, index)}
+                  </motion.div>
+                ))}
+              </CardsGrid>
+            </motion.div>
+          ) : (
+            <motion.div
+              initial={{ opacity: 0, scale: 0.9 }}
+              animate={{ opacity: 1, scale: 1 }}
+              transition={{ delay: 0.2, duration: 0.4 }}
+            >
+              <EmptyState>
+                <EmptyTitle>아직 추가된 항목이 없습니다</EmptyTitle>
+                <EmptyDescription>나중에 추가하셔도 괜찮습니다. 다음 단계로 진행해보세요.</EmptyDescription>
+              </EmptyState>
+            </motion.div>
+          )}
+        </Content>
+
+        {/* 버튼은 Container 하단에 고정 */}
+        <ButtonContainer>
+          <motion.div
+            initial={{ opacity: 0, y: 20 }}
+            animate={{ opacity: 1, y: 0 }}
+            transition={{
+              delay: currentSection.items.length * 0.15 + 0.3,
+              duration: 0.5,
+            }}
+          >
+            <Button onClick={handleNext} whileHover={{ scale: 1.05 }} whileTap={{ scale: 0.95 }}>
+              {step < sections.length - 1 ? '다음 단계로 →' : '🚀 지금 챗봇 시작하기'}
+            </Button>
+          </motion.div>
+        </ButtonContainer>
+      </Container>
+    </Wrapper>
+  );
+};
+
+export default CareerStepper;

--- a/src/components/login/CommonForm.tsx
+++ b/src/components/login/CommonForm.tsx
@@ -247,7 +247,7 @@ const CommonForm = ({ pageType }: CommonFormProps) => {
       const response = await loginApi(userId, password);
       const { memberId, profileId, memberName, gender } = response.result;
       setUser(memberId, profileId, memberName, gender);
-      navigate('/main');
+      navigate('/careerintro');
     } catch (error: any) {
       alert('로그인 실패: ' + (error.response?.message || error.message));
     }

--- a/src/components/profile/card/CertificationCard.tsx
+++ b/src/components/profile/card/CertificationCard.tsx
@@ -5,7 +5,7 @@ import { Certification } from '../../../types/certification';
 
 interface CertificationCardProps {
   certification: Certification;
-  onDelete: () => void;
+  onDelete?: () => void;
 }
 
 const CertificationCard = ({ certification, onDelete }: CertificationCardProps) => {
@@ -15,11 +15,13 @@ const CertificationCard = ({ certification, onDelete }: CertificationCardProps) 
         <CertificationName>
           {certification.name} <CertificationDate>{certification.acquisitedAt}</CertificationDate>
         </CertificationName>
-        <ActionButtons>
-          <IconButton onClick={onDelete} $isDelete>
-            <FiTrash2 size={18} />
-          </IconButton>
-        </ActionButtons>
+        {onDelete && (
+          <ActionButtons>
+            <IconButton onClick={onDelete} $isDelete>
+              <FiTrash2 size={18} />
+            </IconButton>
+          </ActionButtons>
+        )}
       </CardHeader>
     </CardWrapper>
   );

--- a/src/components/profile/card/ExperienceCard.tsx
+++ b/src/components/profile/card/ExperienceCard.tsx
@@ -5,7 +5,7 @@ import { Experience } from '../../../types/experience';
 
 interface ExperienceCardProps {
   experience: Experience;
-  onDelete: (id: number) => void;
+  onDelete?: (id: number) => void;
 }
 
 const ExperienceCard = ({ experience, onDelete }: ExperienceCardProps) => {
@@ -15,11 +15,13 @@ const ExperienceCard = ({ experience, onDelete }: ExperienceCardProps) => {
         <ExperienceName>
           {`[${experience.experienceName}]`} <ExperienceDate>{experience.experiencedAt}</ExperienceDate>
         </ExperienceName>
-        <ActionButtons>
-          <IconButton onClick={() => onDelete(experience.id)} $isDelete>
-            <FiTrash2 size={18} />
-          </IconButton>
-        </ActionButtons>
+        {onDelete && (
+          <ActionButtons>
+            <IconButton onClick={() => onDelete(experience.id)} $isDelete>
+              <FiTrash2 size={18} />
+            </IconButton>
+          </ActionButtons>
+        )}
       </CardHeader>
 
       <ExperienceDetails>

--- a/src/components/profile/card/ProjectCard.tsx
+++ b/src/components/profile/card/ProjectCard.tsx
@@ -5,7 +5,7 @@ import { Project } from '../../../types/project';
 
 interface ProjectCardProps {
   project: Project;
-  onDelete: () => void;
+  onDelete?: () => void;
 }
 
 const ProjectCard = ({ project, onDelete }: ProjectCardProps) => {
@@ -15,11 +15,13 @@ const ProjectCard = ({ project, onDelete }: ProjectCardProps) => {
         <ProjectTitle>
           {project.title} <ProjectPeriod>{project.period}</ProjectPeriod>
         </ProjectTitle>
-        <ActionButtons>
-          <IconButton onClick={onDelete} $isDelete>
-            <FiTrash2 size={18} />
-          </IconButton>
-        </ActionButtons>
+        {onDelete && (
+          <ActionButtons>
+            <IconButton onClick={onDelete} $isDelete>
+              <FiTrash2 size={18} />
+            </IconButton>
+          </ActionButtons>
+        )}
       </CardHeader>
 
       <ProjectDetails>
@@ -30,7 +32,7 @@ const ProjectCard = ({ project, onDelete }: ProjectCardProps) => {
           프로젝트 규모: <DetailValue>{project.projectSize}</DetailValue>
         </DetailItem>
         <DetailItem>
-          역할: <DetailValue>{project.role}</DetailValue>
+          역할: <DetailValue>{project.role.join(', ')}</DetailValue>
         </DetailItem>
       </ProjectDetails>
 

--- a/src/pages/CareerIntroPage.tsx
+++ b/src/pages/CareerIntroPage.tsx
@@ -1,0 +1,98 @@
+import React, { useEffect, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import styled from 'styled-components';
+import CareerReveal from '../components/career/CareerReveal';
+import CareerStepper from '../components/career/CareerStepper';
+
+import ProjectCard from '../components/profile/card/ProjectCard';
+import ExperienceCard from '../components/profile/card/ExperienceCard';
+import CertificationCard from '../components/profile/card/CertificationCard';
+
+import { Project } from '../types/project';
+import { Experience } from '../types/experience';
+import { Certification } from '../types/certification';
+
+import { fetchProjectAll } from '../api/project';
+import { fetchExperienceAll } from '../api/experience';
+import { fetchCertificationAll } from '../api/certi';
+import { mapProjectResponseToProject, mapCertificationResponseToCertification } from '../utils/ProjectMappers';
+
+const CareerIntroContainer = styled.div`
+  padding: 3rem;
+`;
+
+const CareerIntroPage = () => {
+  const [showDetails, setShowDetails] = useState(false);
+  const navigate = useNavigate();
+  const [projectList, setProjectList] = useState<Project[]>([]);
+  const [experienceList, setExperienceList] = useState<Experience[]>([]);
+  const [certificationList, setCertificationList] = useState<Certification[]>([]);
+
+  useEffect(() => {
+    const timer = setTimeout(() => setShowDetails(true), 6000);
+    return () => clearTimeout(timer);
+  }, []);
+
+  useEffect(() => {
+    const fetchDataAll = async () => {
+      try {
+        const [projectResponse, experienceResponse, certificationResponse] = await Promise.all([
+          fetchProjectAll(),
+          fetchExperienceAll(),
+          fetchCertificationAll(),
+        ]);
+        const mappedProjects = projectResponse.map(mapProjectResponseToProject);
+        setProjectList(mappedProjects);
+
+        const experienceData: Experience[] = experienceResponse.map((item: any) => ({
+          id: item.experienceId,
+          experienceName: item.experienceName,
+          experienceDescribe: item.experienceDescribe,
+          experiencedAt: item.experiencedAt,
+        }));
+        setExperienceList(experienceData);
+
+        const mappedCertifications = certificationResponse.map(mapCertificationResponseToCertification);
+        setCertificationList(mappedCertifications);
+      } catch (error) {
+        console.error('데이터 불러오기 실패:', error);
+      }
+    };
+
+    fetchDataAll();
+  }, []);
+
+  const sections = [
+    {
+      title: '📁 프로젝트',
+      items: projectList,
+      renderItem: (item: Project, index: number) => <ProjectCard key={item.id} project={item} />,
+    },
+    {
+      title: '💡 경험',
+      items: experienceList,
+      renderItem: (item: Experience, index: number) => <ExperienceCard key={item.id} experience={item} />,
+    },
+    {
+      title: '📜 자격증',
+      items: certificationList,
+      renderItem: (item: Certification, index: number) => <CertificationCard key={item.id} certification={item} />,
+    },
+  ];
+
+  return (
+    <CareerIntroContainer>
+      {!showDetails ? (
+        <CareerReveal
+          projectCount={projectList.length}
+          experienceCount={experienceList.length}
+          certificationCount={certificationList.length}
+        />
+      ) : (
+        <CareerStepper<any> sections={sections} onComplete={() => navigate('/main')} />
+      )}
+    </CareerIntroContainer>
+  );
+};
+
+export default CareerIntroPage;

--- a/src/routes/AppRouter.tsx
+++ b/src/routes/AppRouter.tsx
@@ -9,6 +9,7 @@ import RegisterPage from '../pages/RegisterPage';
 import ChatPage from '../pages/ChatPage';
 import RoleModelPage from '../pages/RoleModelPage';
 import ProfilePage from '../pages/ProfilePage';
+import CareerIntroPage from '../pages/CareerIntroPage';
 
 function AppRouter() {
   return (
@@ -25,6 +26,7 @@ function AppRouter() {
         <Route path="/chat/:sessionId" element={<ChatPage />} />
         <Route path="/rolemodel/*" element={<RoleModelPage />} />
         <Route path="/profile" element={<ProfilePage />} />
+        <Route path="/careerintro" element={<CareerIntroPage />} />
       </Routes>
     </BrowserRouter>
   );

--- a/src/types/certification.ts
+++ b/src/types/certification.ts
@@ -8,3 +8,9 @@ export interface CertificationDto {
   certificationId: number | string;
   acquisitionDate: string;
 }
+
+export interface CertificationResponse {
+  certificationId: number;
+  certificationName: string;
+  acquisitionDate: string;
+}

--- a/src/types/project.ts
+++ b/src/types/project.ts
@@ -19,3 +19,16 @@ export interface ProjectFormDto {
   skillSetIds: (string | number)[];
   isTurningPoint: boolean;
 }
+
+export interface ProjectResponse {
+  projectId: number;
+  projectName: string;
+  projectDescribe: string;
+  startYear: number;
+  endYear: number;
+  projectSize: string;
+  isTurningPoint: boolean;
+  domainName: string;
+  skillSets: string[];
+  roles: string[];
+}

--- a/src/utils/ProjectMappers.ts
+++ b/src/utils/ProjectMappers.ts
@@ -1,4 +1,6 @@
 import { OptionType } from '../components/common/CustomSelect';
+import { CertificationResponse, Certification } from '../types/certification';
+import { Project, ProjectResponse } from '../types/project';
 
 // 공통 매퍼 함수 (id -> label)
 export const getLabelById = (id: string | number, options: OptionType[]): string => {
@@ -40,3 +42,19 @@ export const getProjectSize = (projectSize: string | number) => {
       return '없음';
   }
 };
+
+export const mapProjectResponseToProject = (data: ProjectResponse): Project => ({
+  id: data.projectId,
+  title: `[${data.projectName}]`,
+  period: `${data.startYear}년차 ~ ${data.endYear}년차`,
+  domain: data.domainName,
+  projectSize: data.projectSize,
+  role: data.roles,
+  skills: data.skillSets,
+});
+
+export const mapCertificationResponseToCertification = (data: CertificationResponse): Certification => ({
+  id: data.certificationId,
+  name: `[${data.certificationName}]`,
+  acquisitedAt: data.acquisitionDate,
+});


### PR DESCRIPTION
## 🔥 작업 개요

- 로그인 시 커리어 요약 페이지 구현
- 프로젝트, 경험, 자격증 정보 표시
- API 연동

## ✅ 관련 이슈

- close #47 

## ✨ 주요 변경사항

- 커리어 정보 표시 페이지 구현
- Project/Experience/Certification 카드 컴포넌트 수정 (삭제 아이콘 Optional)

## 📸 스크린샷(선택)

![화면 기록 2025-06-25 오전 11 23 17](https://github.com/user-attachments/assets/7f2239e0-4ad5-40bc-8feb-6029be130bb7)

## 🧪 테스트 (선택)

## 📝 ETC (선택)
